### PR TITLE
Added handling for junk in the .mozilla/firefox profiles directory

### DIFF
--- a/extract_cookies.py
+++ b/extract_cookies.py
@@ -60,7 +60,15 @@ def find_cookie_dir():
     ffdir = Path.home().joinpath(".mozilla/firefox/")
     paths = sorted(Path(ffdir).iterdir(), key=os.path.getatime)
 
-    return paths[-1].joinpath("cookies.sqlite")
+    # Add some smarter filtering to make sure the directory we're requesting
+    # is a profile and not some junk directory.
+    valid_paths = [
+        candidate
+        for candidate in paths
+        if candidate.joinpath(Path("cookies.sqlite")).exists()
+    ]
+
+    return valid_paths[-1].joinpath("cookies.sqlite")
 
 
 def main():


### PR DESCRIPTION
For some reason Firefox has created some sort of junk directory in `~/.mozilla/firefox` that confuses the extractor. I added a small tweak to make sure it only pulls directories that contain a `cookes.sqlite` directory for the result.